### PR TITLE
Added condition on new dataset_model variable to skip solvers

### DIFF
--- a/datasets/bodyfat.py
+++ b/datasets/bodyfat.py
@@ -19,4 +19,4 @@ class Dataset(BaseDataset):
         X, y = fetch_libsvm("bodyfat")
         X = (X - np.mean(X, axis=0)) / np.std(X, axis=0)
 
-        return dict(X=X, y=y)
+        return dict(X=X, y=y, dataset_model=['linreg'])

--- a/datasets/breast_cancer.py
+++ b/datasets/breast_cancer.py
@@ -23,4 +23,4 @@ class Dataset(BaseDataset):
         binarizer = LabelBinarizer(neg_label=-1, pos_label=1)
         y = binarizer.fit_transform(y)[:, 0].astype(X.dtype)
 
-        return dict(X=X, y=y)
+        return dict(X=X, y=y, dataset_model=['logreg'])

--- a/datasets/diabetes.py
+++ b/datasets/diabetes.py
@@ -18,4 +18,4 @@ class Dataset(BaseDataset):
     def get_data(self):
         X, y = load_diabetes(return_X_y=True)
         X = (X - np.mean(X, axis=0)) / np.std(X, axis=0)
-        return dict(X=X, y=y)
+        return dict(X=X, y=y, dataset_model=['linreg'])

--- a/datasets/housing.py
+++ b/datasets/housing.py
@@ -18,4 +18,4 @@ class Dataset(BaseDataset):
     def get_data(self):
         X, y = fetch_california_housing(return_X_y=True)
         X = (X - np.mean(X, axis=0)) / np.std(X, axis=0)
-        return dict(X=X, y=y)
+        return dict(X=X, y=y, dataset_model=['linreg'])

--- a/datasets/simulated.py
+++ b/datasets/simulated.py
@@ -37,7 +37,9 @@ class Dataset(BaseDataset):
         X = (X - np.mean(X, axis=0)) / np.std(X, axis=0)
         if self.binary:
             y = np.sign(X @ beta)
+            dataset_model = ['logreg']
         else:
             y = X @ beta
+            dataset_model = ['linreg']
 
-        return dict(X=X, y=y)
+        return dict(X=X, y=y, dataset_model=dataset_model)

--- a/objective.py
+++ b/objective.py
@@ -17,11 +17,16 @@ class Objective(BaseObjective):
         self.model = model
 
     def set_data(self, X, y, dataset_model):
-        if self.model == 'logreg' and self.model in dataset_model:
-            if set(y) != set([-1, 1]):
-                raise ValueError(
-                    f"y must contain only -1 or 1 as values. Got {set(y)}"
-                )
+        supported_model = "logreg"
+        if (
+            self.model in dataset_model and
+            self.model == supported_model and
+            set(y) != set([-1, 1])
+        ):
+              raise ValueError(
+                  f"y must contain only -1 or 1 as values for the {supported_model} "
+                  f"model. Currently: set(y) = {set(y)}"
+              )
 
         self.X, self.y, self.dataset_model = X, y, dataset_model
 

--- a/objective.py
+++ b/objective.py
@@ -16,14 +16,14 @@ class Objective(BaseObjective):
     def __init__(self, model='linreg'):
         self.model = model
 
-    def set_data(self, X, y):
-        if self.model == 'logreg':
+    def set_data(self, X, y, dataset_model):
+        if self.model == 'logreg' and self.model in dataset_model:
             if set(y) != set([-1, 1]):
                 raise ValueError(
                     f"y must contain only -1 or 1 as values. Got {set(y)}"
                 )
 
-        self.X, self.y = X, y
+        self.X, self.y, self.dataset_model = X, y, dataset_model
 
     def get_one_result(self):
         n_features = self.X.shape[1]
@@ -39,4 +39,4 @@ class Objective(BaseObjective):
             return objective_function_linreg(X, y, beta)
 
     def get_objective(self):
-        return dict(X=self.X, y=self.y, model=self.model)
+        return dict(X=self.X, y=self.y, model=self.model, dataset_model=self.dataset_model)

--- a/solvers/lbfgs.py
+++ b/solvers/lbfgs.py
@@ -24,7 +24,7 @@ class Solver(BaseSolver):
 
     def skip(self, X, y, model, dataset_model):
         if model not in dataset_model:
-            return True, "model not suitable for this dataset"
+            return True, f"{model} not suitable for this dataset"
 
         return False, None
 

--- a/solvers/lbfgs.py
+++ b/solvers/lbfgs.py
@@ -19,8 +19,14 @@ class Solver(BaseSolver):
 
     requirements = []
 
-    def set_objective(self, X, y, model):
-        self.X, self.y, self.model = X, y, model
+    def set_objective(self, X, y, model, dataset_model):
+        self.X, self.y, self.model, self.dataset_model = X, y, model, dataset_model
+
+    def skip(self, X, y, model, dataset_model):
+        if model not in dataset_model:
+            return True, "model not suitable for this dataset"
+
+        return False, None
 
     def run(self, n_iter):
         if self.model == 'logreg':

--- a/solvers/nesterovgd.py
+++ b/solvers/nesterovgd.py
@@ -24,8 +24,14 @@ class Solver(BaseSolver):
         if self.model == 'linreg':
             return gradient_linreg(X, y, w)
 
-    def set_objective(self, X, y, model):
-        self.X, self.y, self.model = X, y, model
+    def set_objective(self, X, y, model, dataset_model):
+        self.X, self.y, self.model, self.dataset_model = X, y, model, dataset_model
+
+    def skip(self, X, y, model, dataset_model):
+        if model not in dataset_model:
+            return True, "model not suitable for this dataset"
+
+        return False, None
 
     def run(self, n_iter):
 

--- a/solvers/nesterovgd.py
+++ b/solvers/nesterovgd.py
@@ -29,7 +29,7 @@ class Solver(BaseSolver):
 
     def skip(self, X, y, model, dataset_model):
         if model not in dataset_model:
-            return True, "model not suitable for this dataset"
+            return True, f"{model} not suitable for this dataset"
 
         return False, None
 

--- a/solvers/pythongd.py
+++ b/solvers/pythongd.py
@@ -14,7 +14,7 @@ class Solver(BaseSolver):
 
     def skip(self, X, y, model, dataset_model):
         if model not in dataset_model:
-            return True, "model not suitable for this dataset"
+            return True, f"{model} not suitable for this dataset"
 
         return False, None
 

--- a/solvers/pythongd.py
+++ b/solvers/pythongd.py
@@ -9,8 +9,14 @@ with safe_import_context() as import_ctx:
 class Solver(BaseSolver):
     name = 'Python-GD'  # gradient descent
 
-    def set_objective(self, X, y, model):
-        self.X, self.y, self.model = X, y, model
+    def set_objective(self, X, y, model, dataset_model):
+        self.X, self.y, self.model, self.dataset_model = X, y, model, dataset_model
+
+    def skip(self, X, y, model, dataset_model):
+        if model not in dataset_model:
+            return True, "model not suitable for this dataset"
+
+        return False, None
 
     def gradient(self, X, y, w):
         if self.model == 'logreg':

--- a/solvers/scipy.py
+++ b/solvers/scipy.py
@@ -12,13 +12,14 @@ class Solver(BaseSolver):
     install_cmd = "conda"
     parameters = {"solver": ["cgs", "tfqmr"]}
 
-    def set_objective(self, X, y, model):
-        if model != 'linreg':
-            print("Please choose the 'linreg' to use scipy solver")
-            # Stop execution by raising an exception
-            raise ValueError("Wrong model for solver")
+    def set_objective(self, X, y, model, dataset_model):
+        self.X, self.y, self.model, self.dataset_model = X, y, model, dataset_model
 
-        self.X, self.y = X, y
+    def skip(self, X, y, model, dataset_model):
+        if model not in dataset_model or model not in ['linreg']:
+            return True, "model not suitable for this dataset"
+
+        return False, None
 
     def run(self, n_iter):
         X, y = self.X, self.y

--- a/solvers/scipy.py
+++ b/solvers/scipy.py
@@ -17,7 +17,7 @@ class Solver(BaseSolver):
 
     def skip(self, X, y, model, dataset_model):
         if model not in dataset_model or model not in ['linreg']:
-            return True, "model not suitable for this dataset"
+            return True, f"{model} not suitable for this dataset"
 
         return False, None
 

--- a/solvers/sklearn.py
+++ b/solvers/sklearn.py
@@ -26,13 +26,8 @@ class Solver(BaseSolver):
     }
     parameter_template = "{solver}"
 
-    def set_objective(self, X, y, model):
-        if model != 'multilogreg' and model != 'logreg':
-            print("Please choose a logistic model to use this solver")
-            # Stop execution by raising an exception
-            raise ValueError("Wrong model for solver")
-
-        self.X, self.y = X, y
+    def set_objective(self, X, y, model, dataset_model):
+        self.X, self.y, self.model, self.dataset_model = X, y, model, dataset_model
 
         warnings.filterwarnings('ignore', category=ConvergenceWarning)
         warnings.filterwarnings('ignore', category=LineSearchWarning)
@@ -49,6 +44,12 @@ class Solver(BaseSolver):
                 solver=self.solver,
                 penalty=None, fit_intercept=False, tol=1e-10
             )
+
+    def skip(self, X, y, model, dataset_model):
+        if model not in dataset_model or model not in ['logreg']:
+            return True, "model not suitable for this dataset"
+
+        return False, None
 
     def run(self, n_iter):
         if self.solver == "sgd":

--- a/solvers/sklearn.py
+++ b/solvers/sklearn.py
@@ -47,7 +47,7 @@ class Solver(BaseSolver):
 
     def skip(self, X, y, model, dataset_model):
         if model not in dataset_model or model not in ['logreg']:
-            return True, "model not suitable for this dataset"
+            return True, f"{model} not suitable for this dataset"
 
         return False, None
 


### PR DESCRIPTION
 - added new `dataset_model` variable to require specific models for each dataset.
 - in `objective.py`, added extra conditions on `logreg` model in case a user tries running it on a logreg dataset but not with -1 and 1 outputs.
 - added skip method in all solvers to ignore cases when `model` and `dataset_model` are mismatched, or when the solver is incompatible with `model`.